### PR TITLE
removing additional trailing slashes

### DIFF
--- a/packages/decoupled/src/lib/trailing-slash.test.ts
+++ b/packages/decoupled/src/lib/trailing-slash.test.ts
@@ -1,0 +1,20 @@
+import { fixTrailingSlash, shouldFixTrailingSlash } from './trailing-slash';
+
+const runCases = (cases, hostname?: string) => {
+    cases.forEach((testCase, index) => {
+        test(`#${index} (${testCase.request})`, () => {
+            const should = shouldFixTrailingSlash(testCase.request);
+            const result = fixTrailingSlash(testCase.request);
+            expect(should === false ? testCase.request : result).toBe(testCase.expect);
+        });
+    });
+};
+
+describe('Trailing Slashes', () => {
+    runCases([
+        { request: 'http://www.domain1.tld/resource', expect: 'http://www.domain1.tld/resource/' },
+        { request: 'http://www.domain1.tld/resource/', expect: 'http://www.domain1.tld/resource/' },
+        { request: 'http://www.domain1.tld/resource//', expect: 'http://www.domain1.tld/resource/' },
+        { request: 'http://www.domain1.tld/resource///////', expect: 'http://www.domain1.tld/resource/' },
+    ])
+});

--- a/packages/decoupled/src/lib/trailing-slash.test.ts
+++ b/packages/decoupled/src/lib/trailing-slash.test.ts
@@ -21,7 +21,7 @@ describe('Trailing Slashes', () => {
             { request: 'http://www.domain1.tld/resource//', expect: expected },
             { request: 'http://www.domain1.tld/resource///////', expect: expected },
             { request: `http://www.domain1.tld/resource${randomSlahes}`, expect: expected },
-            { request: `http://www.domain1.tld/resource${'/'.repeat(10000)}`, expect: expected },
+            { request: `http://www.domain1.tld/resource${'/'.repeat(1000000)}`, expect: expected },
         ])
     });
     describe('Detect if there are more than one trailing slash', () => {

--- a/packages/decoupled/src/lib/trailing-slash.test.ts
+++ b/packages/decoupled/src/lib/trailing-slash.test.ts
@@ -1,20 +1,41 @@
-import { fixTrailingSlash, shouldFixTrailingSlash } from './trailing-slash';
+import { fixTrailingSlash, shouldFixTrailingSlash, hasMultipleTrailingSlash } from './trailing-slash';
 
 const runCases = (cases, hostname?: string) => {
     cases.forEach((testCase, index) => {
         test(`#${index} (${testCase.request})`, () => {
             const should = shouldFixTrailingSlash(testCase.request);
             const result = fixTrailingSlash(testCase.request);
-            expect(should === false ? testCase.request : result).toBe(testCase.expect);
+            expect(should === false ? testCase.request : testCase.expect).toBe(result);
         });
     });
 };
 
+const randomSlahes = '/'.repeat(Math.floor(Math.random() * (1000 - 3 + 1) ) + 3);
+
 describe('Trailing Slashes', () => {
-    runCases([
-        { request: 'http://www.domain1.tld/resource', expect: 'http://www.domain1.tld/resource/' },
-        { request: 'http://www.domain1.tld/resource/', expect: 'http://www.domain1.tld/resource/' },
-        { request: 'http://www.domain1.tld/resource//', expect: 'http://www.domain1.tld/resource/' },
-        { request: 'http://www.domain1.tld/resource///////', expect: 'http://www.domain1.tld/resource/' },
-    ])
+    describe('it will process RegExp-URLs properly', () => {
+        const expected = 'http://www.domain1.tld/resource/';
+        runCases([
+            { request: 'http://www.domain1.tld/resource', expect: expected },
+            { request: 'http://www.domain1.tld/resource/', expect: expected },
+            { request: 'http://www.domain1.tld/resource//', expect: expected },
+            { request: 'http://www.domain1.tld/resource///////', expect: expected },
+            { request: `http://www.domain1.tld/resource${randomSlahes}`, expect: expected },
+            { request: `http://www.domain1.tld/resource${'/'.repeat(10000)}`, expect: expected },
+        ])
+    });
+    describe('Detect if there are more than one trailing slash', () => {
+        test('No trailing slash, should return false', () => {
+            expect(hasMultipleTrailingSlash('http://www.domain1.tld/resource')).toBeFalsy();
+        });
+        test('One trailing slash, should return false', () => {
+            expect(hasMultipleTrailingSlash('http://www.domain1.tld/resource/')).toBeFalsy();
+        });
+        test('Two trailing slash, should return true', () => {
+            expect(hasMultipleTrailingSlash('http://www.domain1.tld/resource//')).toBeTruthy();
+        });
+        test('Random 3-1000 More than two trailing slashes, should return true', () => {
+            expect(hasMultipleTrailingSlash(`http://www.domain1.tld/resource${randomSlahes}`)).toBeTruthy();
+        });
+    });
 });

--- a/packages/decoupled/src/lib/trailing-slash.ts
+++ b/packages/decoupled/src/lib/trailing-slash.ts
@@ -7,10 +7,19 @@ export const isFilename = (url: string): boolean => /[\w-%]+\.(\w+)$/.test(url);
 
 export const hasTrailingSlash = (url: string): boolean => /(.+)\/$/.test(url);
 
+export const hasMultipleTrailingSlash = (url: string): boolean => /(.+)[^:][\/]{2}$/.test(url);
+
 export const shouldFixTrailingSlash =
-    (url: string): boolean => url.length > 1 && !hasTrailingSlash(url) && !isFilename(url);
+    (url: string): boolean => url.length > 1 && ( !hasTrailingSlash(url) && !isFilename(url) ) || hasMultipleTrailingSlash(url);
 
 export const fixTrailingSlash = (url: string): string => {
+
+    if (hasMultipleTrailingSlash(url)) {
+        do {
+            url = url.slice(0, -1);
+        } while (hasMultipleTrailingSlash(url));
+        return url;
+    }
 
     if (!shouldFixTrailingSlash(url)) {
         return url;

--- a/packages/decoupled/src/lib/trailing-slash.ts
+++ b/packages/decoupled/src/lib/trailing-slash.ts
@@ -7,23 +7,18 @@ export const isFilename = (url: string): boolean => /[\w-%]+\.(\w+)$/.test(url);
 
 export const hasTrailingSlash = (url: string): boolean => /(.+)\/$/.test(url);
 
-export const hasMultipleTrailingSlash = (url: string): boolean => /(.+)[^:][\/]{2}$/.test(url);
+export const hasMultipleTrailingSlash = (url: string): boolean => /(\/+){2}$/.test(url);
 
 export const shouldFixTrailingSlash =
     (url: string): boolean => url.length > 1 && ( !hasTrailingSlash(url) && !isFilename(url) ) || hasMultipleTrailingSlash(url);
 
 export const fixTrailingSlash = (url: string): string => {
 
-    if (hasMultipleTrailingSlash(url)) {
-        do {
-            url = url.slice(0, -1);
-        } while (hasMultipleTrailingSlash(url));
-        return url;
-    }
-
     if (!shouldFixTrailingSlash(url)) {
         return url;
     }
+
+    url = url.replace(/(\/+)$/, '');
 
     return `${url}/`;
 


### PR DESCRIPTION
This will redirect to the canonical address those request made with multiple forward slashes at the end of the URL

TestCase included